### PR TITLE
Require symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "twig/twig": "^1.0|^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4,<6.0.0"
+        "phpunit/phpunit": ">=4,<6.0.0",
+        "symfony/phpunit-bridge": "^4.2"
     },
     "autoload": {
         "psr-4": { "Ps\\PdfBundle\\": "src" }

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,23 @@
             "email":    "me@psliwa.org"
         }     
     ],
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
     "require": {
         "php": "^7.1",
-        "symfony/symfony": "~2.3|~3.0",
+        "doctrine/annotations": "^1.0",
         "psliwa/php-pdf": "^1.1.5",
-        "sensio/framework-extra-bundle": "^2|^3|^4|^5"
+        "sensio/framework-extra-bundle": "^2|^3|^4|^5",
+        "symfony/config": "^2.3|^3.0",
+        "symfony/dependency-injection": "^2.3|^3.0",
+        "symfony/event-dispatcher": "^2.3|^3.0",
+        "symfony/framework-bundle": "^2.3|^3.0",
+        "symfony/http-foundation": "^2.3|^3.0",
+        "symfony/http-kernel": "^2.3|^3.0",
+        "symfony/templating": "^2.3|^3.0",
+        "twig/twig": "^1.0|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4,<6.0.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,6 +4,10 @@
         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.0/phpunit.xsd"
         bootstrap="vendor/autoload.php">
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
+
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>


### PR DESCRIPTION
This stops requiring the full `symfony/symfony` package, and starts requiring the deprecation listener in the tests, to make upgrade easier later.